### PR TITLE
Feat 帳簿バックエンド

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,121 @@
 
----
+# sanbou_app
 
-## プロジェクト概要
-
-このリポジトリは、Webアプリケーション「sanbou_app」の開発・運用に必要な各種サービス（フロントエンド、バックエンド、AI API、DB、Nginx等）をDocker Composeで一元管理するための構成です。
+フロントエンド（Vite + React）と複数のFastAPIサービス、PostgreSQL、NginxをDocker Composeで統合したWebアプリです。
 
 ---
 
-## ディレクトリ・ファイル構成
+## すぐに起動する（Quick Start）
 
+前提（ローカル開発・Linux想定）
 
-### my-project/
-### envs/
-環境ごとの設定ファイルやサンプル環境変数ファイル（例：`.env.sample`）を管理するディレクトリ。
-開発・本番など用途別に環境変数テンプレートや設定例を配置。
+- Docker / Docker Compose v2 がインストール済み
+- make が利用可能
 
-アプリ本体のディレクトリ。以下のサブディレクトリを含みます：
+手順（開発環境: dev）
 
-- **frontend/**
-  - React + ViteベースのフロントエンドSPA。
-  - `src/`配下に主要な画面・コンポーネント・ロジックを実装。
-  - `public/`には静的ファイル（画像・PDF等）を配置。
+1) 環境変数ファイルを用意
 
-- **backend/**
-  - FastAPIベースのバックエンドAPI群。
-  - AI連携、PDFページ画像生成、質問テンプレートAPIなどを提供。
-  - `app/`配下にAPIエンドポイントやビジネスロジックを実装。
+   - 必須: `env/.env.dev` を作成
+   - 例（必要に応じて調整）:
 
-- **ledger_api/**
-  - 会計データ管理用APIサービス。
-  - 独立したDockerfile・設定・`app/`実装を持つ。
+     ```env
+     POSTGRES_USER=postgres
+     POSTGRES_PASSWORD=postgres
+     POSTGRES_DB=sanbou
+     POSTGRES_PORT=5432
 
-- **sql_api/**
-  - SQLデータベース連携用APIサービス。
-  - DBアクセスやデータ取得APIを提供。
+     # 開発用ポート（衝突時は変更可）
+     FRONTEND_PORT=5173
+     AI_API_PORT=8001
+     LEDGER_API_PORT=8002
+     SQL_API_PORT=8003
+     RAG_API_PORT=8004
+     ```
 
-- **rag_api/**
-  - Retrieval-Augmented Generation（RAG）型AI APIサービス。
-  - ドキュメント検索やAI回答生成を担当。
+   - GCP を使う場合はサービスアカウント鍵を `secrets/gcs-key.json` に配置（devは任意、stg/prodは必須）
 
-- **config/**
-  - CSVやレポート等の各種設定ファイル群。
-  - `csv_config/`や`report_config/`など用途別に整理。
+2) コンテナを起動
 
-- **dbdata/**
-  - DBの永続化データを格納（git管理外）。
-  - ローカル開発や本番用のDBデータを保持。
+   - コマンド:
 
-- **nginx/**
-  - Nginxのリバースプロキシ設定・SSL証明書等を管理。
-  - `conf.d/`に仮想ホスト設定、`certs/`に証明書を配置。
+     ```bash
+     make up ENV=dev
+     ```
 
-- **shared/**
-  - 複数サービスで共通利用するユーティリティや設定。
+3) アクセス
 
-- **backend_shared/**
-  - バックエンド系サービス間で共通利用するモジュールやロジック。
-  - 例：CSVバリデータ、共通設定ローダー等。
+   - Frontend: http://localhost:5173
+   - AI API: http://localhost:8001/docs
+   - Ledger API: http://localhost:8002/docs
+   - SQL API: http://localhost:8003/docs
+   - RAG API: http://localhost:8004/docs
 
+4) 停止・ログ・再ビルド
 
-### .env
-環境変数ファイル。APIキーやDB接続情報などを記載。**機密情報は必ずgit管理外**にしてください。
-
-
-### .gitignore
-バージョン管理から除外するファイル・ディレクトリを定義。`.env`や`dbdata/`など機密・一時データを管理。
-
-
-### docker-compose.yml / docker-compose.override.yml
-各サービス（frontend, backend, db, nginx等）を一括起動・停止できるDocker Compose設定ファイル。
-`override`は開発用の追加設定等に利用。
-
-
-### makefile
-よく使うDockerコマンドやビルドコマンドをまとめた補助スクリプト。
-`make up`や`make down`などで一括操作可能。
+   - 停止: `make down ENV=dev`
+   - ログ: `make logs ENV=dev`（Ctrl+Cで離脱）
+   - 再ビルド: `make rebuild ENV=dev`
 
 ---
 
-## 開発の流れ
+## ステージング/本番での起動（stg/prod）
 
-1. `.env`や`.vscode/`を必要に応じて作成・編集
-2. `docker-compose.yml`・`makefile`で各種サービスを一括管理
-3. アプリ本体の開発・運用は `my-project/` 配下で実施
-4. サービスごとの詳細・技術ドキュメントは `my-project/README.md` などを参照
+1) 環境変数ファイルを用意
+
+- `env/.env.stg` または `env/.env.prod` を作成
+- 初回の `make up` 実行時、`OPENAI_API_KEY` と `GEMINI_API_KEY` を対話入力すると `secrets/.env.<ENV>.secrets` に安全に保存されます
+- GCP利用時は `secrets/gcs-key.json` を必ず配置
+
+2) 起動
+
+```bash
+make up ENV=stg
+# もしくは
+make up ENV=prod
+```
+
+3) Nginx（エッジ）
+
+- stg/prod は Nginx プロファイル（edge）で起動し、80/443 を公開
+- 証明書と設定を配置:
+  - `my-project/nginx/certs/*`（鍵/証明書）
+  - `my-project/nginx/conf.d/*.conf`（仮想ホスト設定）
 
 ---
 
-## 注意事項
+## よくあるエラーと対処
 
-- `.env`やDBデータ等の**機密情報は必ずgit管理から除外**してください（`.gitignore`で管理）。
-- サブディレクトリごとに追加のREADMEや設定ファイルを置くことで、管理・引き継ぎが容易になります。
+- envファイルが見つからない
+  - `env/.env.dev`（または `.env.stg`/`.env.prod`）を作成してから `make up ENV=<env>` を実行
+- ポート競合
+  - `env/.env.<env>` の `FRONTEND_PORT`, `AI_API_PORT` などを空いている番号に変更
+- `secrets/gcs-key.json not found`
+  - GCP連携が必須の環境（stg/prod）ではファイルを配置。devでは警告のみ
 
 ---
 
-## サポート・問い合わせ
+## プロジェクト構成（簡略）
 
-質問や追加要望があれば、プロジェクト管理者・技術担当までご連絡ください。
+- `my-project/frontend`: フロントエンド（Vite + React）
+- `my-project/backend/*_api`: 各FastAPIサービス（ai/ledger/sql/rag）
+- `my-project/nginx`: 逆プロキシ設定と証明書
+- `config`: CSV/レポート等の設定群
+- `dbdata`: PostgreSQLデータ永続化用ボリューム
+- `docker-compose.yml`: 本番相当のベース設定
+- `docker-compose.override.yml`: 開発用の上書き設定（ホットリロードなど）
+- `makefile`: 起動/停止/再ビルドなどの補助
+
+---
+
+## 補足（開発の進め方）
+
+- 日常操作は `make up|down|logs|rebuild ENV=dev` が基本
+- 各サービスの詳細は `my-project/backend/*/README.md` や `frontend/README.md`（存在する場合）を参照
+- 機密情報（APIキー・鍵ファイル・DBデータ）は必ず git 管理外（`.gitignore` 済）
+
+---
+
+## サポート
+
+不明点や要望があれば、プロジェクト管理者まで連絡してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,14 +159,17 @@ services:
       retries: 6
 
   nginx:
-    image: nginx:1.27-alpine
+    build:
+      context: ./my-project
+      dockerfile: nginx/Dockerfile
     profiles: [edge]
     env_file:
       - ${ENV_FILE}
     ports: ["80:80", "443:443"]
     volumes:
-      - ./my-project/nginx/conf.d:/etc/nginx/conf.d:ro
-      - ./my-project/nginx/certs:/etc/nginx/certs:ro
+      - ./my-project/nginx/conf.d:/etc/nginx/conf.d:ro   # 設定をホットリロードしたい場合
+      - ./my-project/nginx/certs:/etc/nginx/certs:ro     # TLS 証明書 (任意)
+      # dist はイメージ内に同梱済みのためマウント不要
     depends_on:
       ai_api:
         condition: service_healthy

--- a/my-project/backend/ledger_api/app/api/endpoints/block_unit_price_interactive.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/block_unit_price_interactive.py
@@ -9,9 +9,13 @@
 
 from typing import Any, Dict
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from app.api.services.report.interactive_report_processing_service import (
+    InteractiveReportProcessingService,
+)
 from app.api.st_app.logic.manage.block_unit_price_interactive import (
     BlockUnitPriceInteractive,
 )
@@ -21,15 +25,8 @@ router = APIRouter()
 tag_name = "Block Unit Price"
 
 
-class StartProcessRequest(BaseModel):
-    """
-    処理開始リクエストモデル
-
-    Attributes:
-        files (Dict[str, Any]): アップロードされたファイルデータ
-    """
-
-    files: Dict[str, Any]  # アップロードされたファイルデータ
+class StartProcessRequest(BaseModel):  # レガシー JSON 経由 (互換用)
+    files: Dict[str, Any]
 
 
 class TransportSelectionRequest(BaseModel):
@@ -46,20 +43,27 @@ class TransportSelectionRequest(BaseModel):
 
 
 class FinalizeRequest(BaseModel):
-    """
-    最終確認リクエストモデル
+    """最終確認リクエストモデル"""
 
-    Attributes:
-        session_data (Dict[str, Any]): 前のステップのセッションデータ
-        confirmed (bool): 確認フラグ
-    """
+    session_data: Dict[str, Any]
+    confirmed: bool = True
 
-    session_data: Dict[str, Any]  # 前のステップのセッションデータ
-    confirmed: bool = True  # 確認フラグ
+
+class GenericApplyRequest(BaseModel):
+    """任意ステップ適用リクエスト"""
+
+    session_data: Dict[str, Any]
+    user_input: Dict[str, Any]
 
 
 @router.post("/initial", tags=[tag_name])
-async def start_block_unit_price_process(request: StartProcessRequest):
+async def start_block_unit_price_process(
+    request: StartProcessRequest | None = None,
+    # 推奨: multipart/form-data で UploadFile を受け取る
+    receive: UploadFile | None = File(None),
+    yard: UploadFile | None = File(None),
+    shipment: UploadFile | None = File(None),
+):
     """
     ブロック単価計算処理開始 (Step 0)
 
@@ -76,13 +80,25 @@ async def start_block_unit_price_process(request: StartProcessRequest):
     """
 
     try:
-        # request.files からファイルを取得
-        files = request.files
-        print(f"Uploaded files: {list(files.keys())}")
+        # 1) UploadFile 優先 (新方式)
+        upload_files: Dict[str, UploadFile] = {}
+        for key, f in {"shipment": shipment}.items():
+            if f is not None:
+                upload_files[key] = f
 
-        # ブロック単価計算プロセッサーの初期化と処理開始
-        processor = BlockUnitPriceInteractive()
-        result = processor.start_process(files)
+        # 2) 後方互換: JSON 経由 (Base64 等) は既存ロジックで使う: files=dict
+        if not upload_files and request is not None:
+            # 既存 BlockUnitPriceInteractive は DataFrame 受領想定なので
+
+            generator = BlockUnitPriceInteractive(files=request.files)
+            # interactive service initial は通常 UploadFile を想定するため、
+            # ここでは直接 initial_step を呼べるよう format 済み dict を前提とするケースを簡易対応
+            # → 実運用ではアップロード方式へ移行推奨
+            return {"status": "deprecated", "message": "Use multipart upload instead."}
+
+        service = InteractiveReportProcessingService()
+        generator = BlockUnitPriceInteractive(files={})
+        result = service.initial(generator, upload_files)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"処理開始エラー: {str(e)}")
@@ -105,16 +121,19 @@ async def select_transport_vendors(request: TransportSelectionRequest):
         HTTPException: 処理中にエラーが発生した場合
     """
     try:
-        # 運搬業者選択の処理実行
-        processor = BlockUnitPriceInteractive()
-        result = processor.process_selection(request.session_data, request.selections)
+        service = InteractiveReportProcessingService()
+        generator = BlockUnitPriceInteractive()
+        # selections は user_input として渡す
+        result = service.apply(
+            generator, request.session_data, {"selections": request.selections}
+        )
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"運搬業者選択エラー: {str(e)}")
 
 
-@router.post("/finalize", tags=[tag_name])
-async def finalize_calculation(request: FinalizeRequest):
+@router.post("/finalize", tags=[tag_name], response_class=StreamingResponse)
+async def finalize_calculation(request: FinalizeRequest) -> StreamingResponse:
     """
     最終計算処理 (Step 2)
 
@@ -130,10 +149,14 @@ async def finalize_calculation(request: FinalizeRequest):
         HTTPException: 処理中にエラーが発生した場合
     """
     try:
-        # 最終計算の実行
-        processor = BlockUnitPriceInteractive()
-        result = processor.finalize_calculation(request.session_data, request.confirmed)
-        return result
+        if not request.confirmed:
+            raise HTTPException(
+                status_code=400, detail="未確認のため finalize できません"
+            )
+        service = InteractiveReportProcessingService()
+        generator = BlockUnitPriceInteractive()
+        response = service.finalize(generator, request.session_data)
+        return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"最終計算エラー: {str(e)}")
 
@@ -181,3 +204,19 @@ async def get_step_info(step: int):
         raise HTTPException(status_code=404, detail="無効なステップです")
 
     return step_info[step]
+
+
+@router.post("/apply", tags=[tag_name])
+async def apply_generic_step(request: GenericApplyRequest):
+    """汎用ステップ適用エンドポイント
+
+    user_input.action もしくは user_input.step に対応するハンドラを呼び出し、
+    任意回数の対話ステップをサポートする。
+    """
+    try:
+        service = InteractiveReportProcessingService()
+        generator = BlockUnitPriceInteractive()
+        result = service.apply(generator, request.session_data, request.user_input)
+        return result
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=f"汎用ステップ適用エラー: {e}")

--- a/my-project/backend/ledger_api/app/api/endpoints/block_unit_price_interactive.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/block_unit_price_interactive.py
@@ -18,6 +18,7 @@ from app.api.st_app.logic.manage.block_unit_price_interactive import (
 
 # APIルーターの初期化
 router = APIRouter()
+tag_name = "Block Unit Price"
 
 
 class StartProcessRequest(BaseModel):
@@ -57,7 +58,7 @@ class FinalizeRequest(BaseModel):
     confirmed: bool = True  # 確認フラグ
 
 
-@router.post("/initial")
+@router.post("/initial", tags=[tag_name])
 async def start_block_unit_price_process(request: StartProcessRequest):
     """
     ブロック単価計算処理開始 (Step 0)
@@ -87,7 +88,7 @@ async def start_block_unit_price_process(request: StartProcessRequest):
         raise HTTPException(status_code=500, detail=f"処理開始エラー: {str(e)}")
 
 
-@router.post("/select-transport")
+@router.post("/select-transport", tags=[tag_name])
 async def select_transport_vendors(request: TransportSelectionRequest):
     """
     運搬業者選択処理 (Step 1)
@@ -112,7 +113,7 @@ async def select_transport_vendors(request: TransportSelectionRequest):
         raise HTTPException(status_code=500, detail=f"運搬業者選択エラー: {str(e)}")
 
 
-@router.post("/finalize")
+@router.post("/finalize", tags=[tag_name])
 async def finalize_calculation(request: FinalizeRequest):
     """
     最終計算処理 (Step 2)
@@ -137,7 +138,7 @@ async def finalize_calculation(request: FinalizeRequest):
         raise HTTPException(status_code=500, detail=f"最終計算エラー: {str(e)}")
 
 
-@router.get("/status/{step}")
+@router.get("/status/{step}", tags=[tag_name])
 async def get_step_info(step: int):
     """
     各ステップの説明情報を取得

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/__init__.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/__init__.py
@@ -2,7 +2,13 @@
 
 from fastapi import APIRouter
 
-from . import balance_sheet, block_unit_price, factory_report
+from . import (
+    average_sheet,
+    balance_sheet,
+    block_unit_price,
+    factory_report,
+    management_sheet,
+)
 
 # 帳票系APIの統合ルーター
 reports_router = APIRouter()
@@ -17,7 +23,17 @@ reports_router.include_router(
 )
 
 reports_router.include_router(
+    average_sheet.router, prefix="/average_sheet", tags=["Average Sheet"]
+)
+
+
+reports_router.include_router(
     block_unit_price.router, prefix="/block_unit_price", tags=["Block Unit Price"]
+)
+
+
+reports_router.include_router(
+    management_sheet.router, prefix="/management_sheet", tags=["Management Sheet"]
 )
 
 # 必要に応じて他の帳票エンドポイントも追加

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/average_sheet.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/average_sheet.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, UploadFile
+from fastapi.responses import Response
+
+from app.api.services.report.concrete_generators import AverageSheetGenerator
+from app.api.services.report.report_processing_service import ReportProcessingService
+
+# APIルーターの初期化
+router = APIRouter()
+
+# 共通処理サービスのインスタンス
+report_service = ReportProcessingService()
+
+
+@router.post("/")
+async def generate_average_sheet(
+    shipment: UploadFile = File(None),
+    yard: UploadFile = File(None),
+    receive: UploadFile = File(None),
+    period_type: Optional[str] = Form(
+        None
+    ),  # "oneday" | "oneweek" | "onemonth"（任意）
+) -> Response:
+    """
+    工場平均表生成APIエンドポイント
+
+    受入・ヤード・出荷一覧から平均表を自動集計します。
+
+    Args:
+            shipment (UploadFile, optional): 出荷データCSVファイル
+            yard (UploadFile, optional): ヤードデータCSVファイル
+            receive (UploadFile, optional): 受入データCSVファイル
+
+    Returns:
+            StreamingResponse: Excel・PDFファイルが含まれたZIPファイル
+    """
+    # アップロードされたファイルの整理
+    files = {k: v for k, v in {"receive": receive}.items() if v is not None}
+
+    # 対象Generatorを直接生成し、共通フローを実行
+    generator = AverageSheetGenerator("average_sheet", files)
+    if period_type:
+        generator.period_type = period_type
+    return report_service.run(generator, files)

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/average_sheet.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/average_sheet.py
@@ -13,7 +13,7 @@ router = APIRouter()
 report_service = ReportProcessingService()
 
 
-@router.post("/")
+@router.post("")
 async def generate_average_sheet(
     shipment: UploadFile = File(None),
     yard: UploadFile = File(None),

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/balance_sheet.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/balance_sheet.py
@@ -15,7 +15,7 @@ router = APIRouter()
 report_service = ReportProcessingService()
 
 
-@router.post("/")
+@router.post("")
 async def generate_balance_sheet(
     shipment: UploadFile = File(None),
     yard: UploadFile = File(None),

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/block_unit_price.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/block_unit_price.py
@@ -15,7 +15,7 @@ router = APIRouter()
 report_service = ReportProcessingService()
 
 
-@router.post("/")
+@router.post("")
 async def generate_block_unit_price_report(
     shipment: UploadFile = File(None),
     yard: UploadFile = File(None),

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/factory_report.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/factory_report.py
@@ -15,7 +15,7 @@ router = APIRouter()
 report_service = ReportProcessingService()
 
 
-@router.post("/")
+@router.post("")
 async def generate_factory_report(
     shipment: UploadFile = File(None),
     yard: UploadFile = File(None),

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/management_sheet.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/management_sheet.py
@@ -13,7 +13,7 @@ router = APIRouter()
 report_service = ReportProcessingService()
 
 
-@router.post("/")
+@router.post("")
 async def generate_management_sheet(
     shipment: UploadFile = File(None),
     yard: UploadFile = File(None),

--- a/my-project/backend/ledger_api/app/api/endpoints/reports/management_sheet.py
+++ b/my-project/backend/ledger_api/app/api/endpoints/reports/management_sheet.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, UploadFile
+from fastapi.responses import Response
+
+from app.api.services.report.concrete_generators import ManagementSheetGenerator
+from app.api.services.report.report_processing_service import ReportProcessingService
+
+# APIルーターの初期化
+router = APIRouter()
+
+# 共通処理サービスのインスタンス
+report_service = ReportProcessingService()
+
+
+@router.post("/")
+async def generate_management_sheet(
+    shipment: UploadFile = File(None),
+    yard: UploadFile = File(None),
+    receive: UploadFile = File(None),
+    period_type: Optional[str] = Form(
+        None
+    ),  # "oneday" | "oneweek" | "onemonth"（任意）
+) -> Response:
+    """
+    管理票（management sheet）生成APIエンドポイント
+
+    受入・ヤード・出荷データから管理票を生成します。
+
+    Args:
+        shipment (UploadFile, optional): 出荷データCSVファイル
+        yard (UploadFile, optional): ヤードデータCSVファイル
+        receive (UploadFile, optional): 受入データCSVファイル
+
+    Returns:
+        StreamingResponse: Excel・PDFファイルが含まれたZIPファイル
+    """
+    # アップロードされたファイルの整理
+    files = {
+        k: v
+        for k, v in {"shipment": shipment, "yard": yard, "receive": receive}.items()
+        if v is not None
+    }
+
+    # 対象Generatorを直接生成し、共通フローを実行
+    generator = ManagementSheetGenerator("management_sheet", files)
+    if period_type:
+        generator.period_type = period_type
+    return report_service.run(generator, files)

--- a/my-project/backend/ledger_api/app/api/services/report/base_interactive_report_generator.py
+++ b/my-project/backend/ledger_api/app/api/services/report/base_interactive_report_generator.py
@@ -1,0 +1,127 @@
+"""Interactive report generator base classes.
+
+インタラクティブ帳票生成の共通基底クラス。
+
+目的:
+ 1. 既存の `BaseReportGenerator` の validate / format / Excel 生成ロジックを再利用
+ 2. main_process を複数ステップ (initial -> N 回の apply -> finalize) に分割
+ 3. セッション状態をシリアライズ/デシリアライズする仕組みを提供
+
+各ステップ概要:
+ initial_step(df_formatted) -> (state_dict, payload_dict)
+   - フロント初回呼び出しで実行。ユーザー入力前の前処理と選択肢生成など。
+
+ apply_step(state_dict, user_input_dict) -> (updated_state, payload_dict)
+   - 中間ステップ。ユーザー選択を逐次反映し、確認用データを返す。
+
+ finalize_step(state_dict) -> (final_result_df, payload_dict)
+   - 最終 DataFrame を返す。payload_dict にはフロント表示用サマリーなど任意情報。
+
+フロントとのデータ受け渡し方針:
+ - state は JSON 化 (DataFrame は df.to_json()) して `session_data` として返却
+ - 次ステップでは `session_data` を受け取り `deserialize_state` で復元
+ - DataFrame の JSON orient はデフォルト (records でない) を使用し、対称性を確保
+
+「保守性」観点の工夫:
+ - 抽象メソッドのインターフェースを最小限にし、共通シリアライズ処理を集中
+ - 将来ステップ追加時は apply_step を複数回呼ぶだけで拡張可能
+ - 非インタラクティブ帳票との共存 (既存 ReportProcessingService.run) を壊さない
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Callable, Dict, Tuple
+
+import pandas as pd
+
+from app.api.services.report.base_report_generator import BaseReportGenerator
+
+SerializedState = Dict[str, Any]
+
+
+class BaseInteractiveReportGenerator(BaseReportGenerator):
+    """インタラクティブ帳票用基底クラス。
+
+    既存 BaseReportGenerator を継承し、ステップ分割された処理インターフェースを追加。
+    """
+
+    # ------- 抽象ステップメソッド -------
+    @abstractmethod
+    def initial_step(
+        self, df_formatted: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """初期ステップ。state, payload を返す。"""
+        raise NotImplementedError
+
+    def apply_step(
+        self, state: Dict[str, Any], user_input: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """中間ステップ (汎用ディスパッチ)
+
+        user_input から以下いずれかを読みステップハンドラを呼び出す:
+          - action (推奨文字列)
+          - step (数値 or 文字列)
+
+        サブクラスは get_step_handlers() をオーバーライドして
+        { "action_name": callable } を返す。callable は
+          (state, user_input) -> (state, payload)
+        を実装する。
+        任意回数呼び出し可能で、最終確定は finalize_step で行う。
+        """
+        handlers = self.get_step_handlers()
+        key = user_input.get("action")
+        if key is None:
+            step_val = user_input.get("step")
+            if step_val is not None:
+                key = str(step_val)
+        if key is None:
+            raise ValueError("ユーザー入力に 'action' も 'step' も存在しません。")
+        handler = handlers.get(str(key))
+        if handler is None:
+            raise ValueError(f"未対応のステップ/アクション: {key}")
+        return handler(state, user_input)
+
+    # サブクラスで必要に応じてオーバーライド
+    def get_step_handlers(
+        self,
+    ) -> Dict[
+        str,
+        Callable[
+            [Dict[str, Any], Dict[str, Any]], Tuple[Dict[str, Any], Dict[str, Any]]
+        ],
+    ]:  # noqa: E501
+        return {}
+
+    @abstractmethod
+    def finalize_step(
+        self, state: Dict[str, Any]
+    ) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+        """最終ステップ。帳票最終 DataFrame と追加情報 payload を返す。"""
+        raise NotImplementedError
+
+    # ------- セッション状態シリアライズ支援 -------
+    def serialize_state(self, state: Dict[str, Any]) -> SerializedState:
+        serialized: Dict[str, Any] = {}
+        for k, v in state.items():
+            if isinstance(v, pd.DataFrame):
+                serialized[k] = {"__df__": True, "value": v.to_json()}
+            else:
+                serialized[k] = v
+        return serialized
+
+    def deserialize_state(self, serialized: SerializedState) -> Dict[str, Any]:
+        state: Dict[str, Any] = {}
+        for k, v in serialized.items():
+            if isinstance(v, dict) and v.get("__df__") and "value" in v:
+                state[k] = pd.read_json(v["value"])
+            else:
+                state[k] = v
+        return state
+
+    # main_process は未使用 (互換のため定義) ---------
+    def main_process(self, df_formatted: Dict[str, Any]):  # type: ignore[override]
+        """非インタラクティブ互換: finalize_step を直接呼ぶ場合のフォールバック。
+        インタラクティブフローでは利用しない。"""
+        final_df, _ = self.finalize_step({"df_formatted": df_formatted})
+        return final_df

--- a/my-project/backend/ledger_api/app/api/services/report/interactive_report_processing_service.py
+++ b/my-project/backend/ledger_api/app/api/services/report/interactive_report_processing_service.py
@@ -1,0 +1,151 @@
+"""Interactive processing service.
+
+ReportProcessingService のインタラクティブ版。
+
+責務:
+ - 初回: CSV 読込 / validate / (期間フィルタ) / format まで共通処理
+ - generator.initial_step を呼び state/payload と session_data を返す
+ - apply: 受け取った session_data を復元し generator.apply_step を呼ぶ
+ - finalize: 復元 -> generator.finalize_step -> Excel/PDF/ZIP StreamingResponse
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import UploadFile
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from app.api.services.report.base_interactive_report_generator import (
+    BaseInteractiveReportGenerator,
+)
+from app.api.services.report.report_processing_service import ReportProcessingService
+
+# (NoFilesUploadedResponse, read_csv_files は base クラス経由で利用しないため削除)
+from backend_shared.src.utils.date_filter_utils import (
+    filter_by_period_from_min_date as shared_filter_by_period_from_min_date,
+)
+
+
+class InteractiveReportProcessingService(ReportProcessingService):
+    """インタラクティブ帳票用サービス"""
+
+    # 既存 _read_uploaded_files を再利用しても良いが、型が同一なのでそのまま呼ぶ
+
+    # -------- Initial --------
+    def initial(
+        self, generator: BaseInteractiveReportGenerator, files: Dict[str, UploadFile]
+    ) -> Dict[str, Any]:
+        dfs, error = self._read_uploaded_files(files)
+        if error:
+            # エラーオブジェクトを可能な限り展開して返す
+            try:
+                if hasattr(error, "to_dict"):
+                    return error.to_dict()
+            except Exception:
+                pass
+            return {"status": "error", "message": str(error)}
+
+        assert dfs is not None
+
+        validation_error = generator.validate(dfs, files)
+        if validation_error:
+            # ErrorApiResponse 系なら内部 payload を dict 化して返す
+            if hasattr(validation_error, "payload"):
+                try:
+                    from backend_shared.src.api_response.response_base import (
+                        _model_to_dict,
+                    )
+
+                    return _model_to_dict(validation_error.payload)
+                except Exception:
+                    pass
+            # フォールバック
+            return {"status": "error", "message": str(validation_error)}
+
+        period_type = getattr(generator, "period_type", None)
+        if period_type:
+            try:
+                dfs = shared_filter_by_period_from_min_date(dfs, period_type)
+            except Exception as e:  # noqa: BLE001
+                print(f"[WARN] date filtering skipped: {e}")
+
+        df_formatted = generator.format(dfs)
+
+        state, payload = generator.initial_step(df_formatted)
+        # state に元 df_formatted が必要なら利用側で含める方針 (明示性)
+        session_data = generator.serialize_state(state)
+
+        return {
+            "status": "success",
+            "step": 0,
+            "message": "initial completed",
+            "data": payload,
+            "session_data": session_data,
+        }
+
+    # -------- Apply (中間) --------
+    def apply(
+        self,
+        generator: BaseInteractiveReportGenerator,
+        session_data: Dict[str, Any],
+        user_input: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        try:
+            state = generator.deserialize_state(session_data)
+            state, payload = generator.apply_step(state, user_input)
+            session_data_updated = generator.serialize_state(state)
+            return {
+                "status": "success",
+                "step": payload.get("step", 1),
+                "message": payload.get("message", "applied"),
+                "data": payload,
+                "session_data": session_data_updated,
+            }
+        except Exception as e:  # noqa: BLE001
+            return {
+                "status": "error",
+                "code": "APPLY_FAILED",
+                "detail": str(e),
+            }
+
+    # -------- Finalize --------
+    def finalize(
+        self,
+        generator: BaseInteractiveReportGenerator,
+        session_data: Dict[str, Any],
+    ) -> StreamingResponse | JSONResponse:
+        try:
+            state = generator.deserialize_state(session_data)
+            final_df, payload = generator.finalize_step(state)
+            try:
+                report_date = payload.get(
+                    "report_date", generator.make_report_date({"result": final_df})
+                )
+            except Exception as e:  # noqa: BLE001
+                # Fallback to today if date extraction fails
+                from datetime import datetime
+
+                print(f"[WARN] report_date fallback due to: {e}")
+                report_date = datetime.now().date().isoformat()
+            response = self.create_response(generator, final_df, report_date)
+            summary = payload.get("summary")
+            if isinstance(summary, dict):
+                for k, v in summary.items():
+                    try:
+                        response.headers[f"X-Summary-{k}"] = str(v)
+                    except Exception:  # noqa: BLE001
+                        pass
+            return response
+        except Exception as e:  # noqa: BLE001
+            # finalize は StreamingResponse 指定のため簡易 JSON を返す
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "status": "error",
+                    "code": "FINALIZE_FAILED",
+                    "detail": str(e),
+                },
+            )

--- a/my-project/backend/ledger_api/requirements-dev.txt
+++ b/my-project/backend/ledger_api/requirements-dev.txt
@@ -1,2 +1,4 @@
 requests
 streamlit
+pytest
+httpx

--- a/my-project/backend/ledger_api/test_interactive_block_unit_price.py
+++ b/my-project/backend/ledger_api/test_interactive_block_unit_price.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8001/ledger_api")
+API_BASE = f"{BASE_URL}/block_unit_price_interactive"
+
+SAMPLE_CSV = Path("/backend/app/data/csv/出荷一覧_20240501.csv")
+
+
+def log(title, obj):
+    print(f"\n==== {title} ====")
+    if isinstance(obj, (dict, list)):
+        print(json.dumps(obj, ensure_ascii=False, indent=2)[:6000])
+    else:
+        print(str(obj)[:6000])
+
+
+def call_initial():
+    if not SAMPLE_CSV.exists():
+        print("Sample CSV missing:", SAMPLE_CSV, file=sys.stderr)
+        sys.exit(1)
+    with SAMPLE_CSV.open("rb") as f:
+        r = requests.post(
+            f"{API_BASE}/initial",
+            files={"shipment": (SAMPLE_CSV.name, f, "text/csv")},
+            timeout=30,
+        )
+    return r
+
+
+def call_apply(session_data, selections):
+    payload = {
+        "session_data": session_data,
+        "user_input": {"action": "select_transport", "selections": selections},
+    }
+    r = requests.post(f"{API_BASE}/apply", json=payload, timeout=30)
+    return r
+
+
+def call_finalize(session_data):
+    payload = {"session_data": session_data, "confirmed": True}
+    r = requests.post(f"{API_BASE}/finalize", json=payload, timeout=60)
+    if r.status_code == 200 and r.headers.get("content-type", "").startswith(
+        "application/zip"
+    ):
+        out = Path("interactive_result.zip")
+        out.write_bytes(r.content)
+        print(f"ZIP saved -> {out} ({out.stat().st_size} bytes)")
+    return r
+
+
+def main():
+    print("Using BASE_URL=", BASE_URL)
+    r0 = call_initial()
+    log("INITIAL RAW", r0.text)
+    try:
+        j0 = r0.json()
+    except Exception:
+        print("Invalid JSON; abort")
+        return
+    log("INITIAL JSON", j0)
+    if j0.get("status") != "success":
+        print("Initial failed; stop.")
+        return
+    session = j0["session_data"]
+    # Build selections from first two options
+    opts = j0.get("data", {}).get("transport_options", [])
+    selections = {}
+    for o in opts[:2]:
+        vendor_name = o.get("vendor_name") or o.get("vendor_code")
+        if vendor_name:
+            selections[vendor_name] = o.get("vendor_code", "")
+    r1 = call_apply(session, selections)
+    log("APPLY RAW", r1.text)
+    j1 = r1.json()
+    log("APPLY JSON", j1)
+    session = j1.get("session_data", session)
+    r2 = call_finalize(session)
+    print("FINAL status", r2.status_code)
+    if r2.headers.get("content-type", "").startswith("application/zip"):
+        print("Finalize returned ZIP.")
+    else:
+        print("Finalize body:", r2.text[:1000])
+
+
+if __name__ == "__main__":
+    main()

--- a/my-project/backend/ledger_api/tests/test_block_unit_price_interactive_flow.py
+++ b/my-project/backend/ledger_api/tests/test_block_unit_price_interactive_flow.py
@@ -1,0 +1,63 @@
+"""最小インタラクティブE2Eテスト (pytest想定)
+
+pytest 実行例:
+  PYTHONPATH=backend:backend/backend_shared/src pytest -q backend/tests/test_block_unit_price_interactive_flow.py
+
+注意: サーバ別起動が不要なように FastAPI TestClient を使用。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_interactive_flow_minimal():
+    # サンプルCSV（必要カラムを満たす）
+    shipment_path = Path("tests/data/sample_shipment_block_unit_price.csv")
+    assert shipment_path.exists()
+
+    # initial
+    with shipment_path.open("rb") as f:
+        res = client.post(
+            "/block_unit_price_interactive/initial",
+            files={"shipment": (shipment_path.name, f, "text/csv")},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body.get("status") == "success"
+    session_data = body.get("session_data")
+    assert session_data
+
+    # apply (skip if no options)
+    transport_options = body.get("data", {}).get("transport_options", [])
+    selections = {}
+    for opt in transport_options[:1]:
+        vendor_name = opt.get("vendor_name") or opt.get("vendor_code")
+        if vendor_name:
+            selections[vendor_name] = opt.get("vendor_code", "")
+    res2 = client.post(
+        "/block_unit_price_interactive/apply",
+        json={
+            "session_data": session_data,
+            "user_input": {"action": "select_transport", "selections": selections},
+        },
+    )
+    assert res2.status_code == 200
+    body2 = res2.json()
+    assert body2.get("status") == "success"
+    session_data2 = body2.get("session_data") or session_data
+
+    # finalize
+    res3 = client.post(
+        "/block_unit_price_interactive/finalize",
+        json={"session_data": session_data2, "confirmed": True},
+    )
+    assert res3.status_code == 200
+    # content-type should be zip
+    assert "application/zip" in res3.headers.get("content-type", "")

--- a/my-project/frontend/src/components/Report/ReportBase.tsx
+++ b/my-project/frontend/src/components/Report/ReportBase.tsx
@@ -3,7 +3,7 @@ import ReportManagePageLayout from './common/ReportManagePageLayout';
 import ReportStepperModal from './common/ReportStepperModal';
 import BlockUnitPriceInteractiveModal from './interactive/BlockUnitPriceInteractiveModal';
 import PDFViewer from './viewer/PDFViewer';
-import { pdfPreviewMap, modalStepsMap, isInteractiveReport } from '../../constants/reportConfig';
+import { pdfPreviewMap, modalStepsMap, isInteractiveReport } from '@/constants/reportConfig';
 import { useReportBaseBusiness } from '../../hooks/report';
 import { useZipProcessing } from '../../hooks/data/useZipProcessing';
 import type { ReportBaseProps } from '../../types/reportBase';

--- a/my-project/frontend/src/components/Report/common/InteractiveReportModal.tsx
+++ b/my-project/frontend/src/components/Report/common/InteractiveReportModal.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Modal, Steps } from 'antd';
-import { modalStepsMap } from '../../../constants/reportConfig';
-import { isInteractiveReport } from '../../../constants/apiEndpoints';
+import { modalStepsMap, isInteractiveReport } from '@/constants/reportConfig';
 import BlockUnitPriceInteractive from '../individual_process/BlockUnitPriceInteractive';
-import type { ReportKey } from '../../../constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 /**
  * インタラクティブ帳簿専用モーダルコンポーネント
@@ -18,20 +17,14 @@ export interface InteractiveReportModalProps {
     open: boolean;
     onCancel: () => void;
     reportKey: ReportKey;
-    csvFiles: { [label: string]: File | null };
     currentStep: number;
-    onStepChange: (step: number) => void;
-    onComplete: (result: { previewUrl?: string; isFinalized?: boolean }) => void;
 }
 
 const InteractiveReportModal: React.FC<InteractiveReportModalProps> = ({
     open,
     onCancel,
     reportKey,
-    csvFiles,
     currentStep,
-    onStepChange,
-    onComplete,
 }) => {
     // インタラクティブ帳簿でない場合は何も表示しない
     if (!isInteractiveReport(reportKey)) {

--- a/my-project/frontend/src/components/Report/common/ReportStepperModal.tsx
+++ b/my-project/frontend/src/components/Report/common/ReportStepperModal.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 
 const { Step } = Steps;
 
-import type { ModalStepConfig } from '../../constants/reportConfig';
+import type { ModalStepConfig } from '@/constants/reportConfig';
 
 export type ReportStepperModalProps = {
     open: boolean;

--- a/my-project/frontend/src/components/Report/individual_process/BlockUnitPriceInteractive.tsx
+++ b/my-project/frontend/src/components/Report/individual_process/BlockUnitPriceInteractive.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { LEDGER_API_URL } from '../../../constants/reportConfig';
+import { LEDGER_API_URL } from '@/constants/reportConfig';
 
 interface TransportOption {
     vendor_code: string;

--- a/my-project/frontend/src/components/Report/interactive/BlockUnitPriceInteractiveModal.tsx
+++ b/my-project/frontend/src/components/Report/interactive/BlockUnitPriceInteractiveModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { Modal, Button, Steps, Spin, message, Space, Card, Select } from 'antd';
 import { CheckCircleOutlined } from '@ant-design/icons';
-import { getApiEndpoint } from '../../../constants/reportConfig';
-import type { ReportKey } from '../../../constants/reportConfig';
+import { getApiEndpoint } from '@/constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 // 型定義（要件に合わせて整備）
 interface TransportVendor {

--- a/my-project/frontend/src/components/chat/QuestionPanel.tsx
+++ b/my-project/frontend/src/components/chat/QuestionPanel.tsx
@@ -82,7 +82,7 @@ const QuestionPanel: React.FC<Props> = ({
     }, [tagOptions]);
 
     return (
-        <div style={{ marginBottom: 8 /* ←狭く */ }}>
+        <div style={{ marginBottom: 16 /* ←狭く */ }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
                 <Typography.Title level={4} style={{ margin: 0 }}>
                     質問を入力

--- a/my-project/frontend/src/constants/reportConfig/index.ts
+++ b/my-project/frontend/src/constants/reportConfig/index.ts
@@ -57,7 +57,7 @@ export const REPORT_KEYS = {
 export type ReportKey = ManageReportKey | FactoryReportKey | LedgerReportKey;
 export const REPORT_OPTIONS = Object.values(REPORT_KEYS);
 
-// ページグループ設定（リファクタリング済み）
+// ページグループ設定
 export const PAGE_REPORT_GROUPS = {
     manage: Object.values(MANAGE_REPORT_KEYS),
     factory: Object.values(FACTORY_REPORT_KEYS),

--- a/my-project/frontend/src/constants/reportConfig/pages/managePageConfig.ts
+++ b/my-project/frontend/src/constants/reportConfig/pages/managePageConfig.ts
@@ -97,20 +97,7 @@ export const manageModalStepsMap: Record<ManageReportKey, ModalStepConfig[]> = {
       showClose: true,
     },
   ],
-  management_sheet: [
-    {
-      label: "帳簿作成中",
-      content: React.createElement("div", {}, "帳票を生成中です"),
-      showNext: true,
-      showClose: false,
-    },
-    {
-      label: "完了",
-      content: React.createElement("div", {}, "完了しました"),
-      showNext: false,
-      showClose: true,
-    },
-  ],
+  management_sheet:[...SIMPLE_CREATE_AND_DONE_STEPS],
 };
 
 // PDFプレビュー設定

--- a/my-project/frontend/src/constants/reportConfig/pages/managePageConfig.ts
+++ b/my-project/frontend/src/constants/reportConfig/pages/managePageConfig.ts
@@ -3,7 +3,7 @@ import React from "react";
 import { CSV_DEFINITIONS } from "../../CsvDefinition";
 import BlockUnitPriceInteractive from "../../../components/Report/individual_process/BlockUnitPriceInteractive";
 import type { CsvConfigGroup, ModalStepConfig } from "../shared/types";
-import { createReportConfig } from "../shared/common";
+import { createReportConfig, SIMPLE_CREATE_AND_DONE_STEPS } from "../shared/common";
 import type { PeriodType } from "../shared/types";
 
 // ==============================
@@ -41,6 +41,8 @@ export const MANAGE_REPORT_KEYS = {
 export type ManageReportKey = keyof typeof MANAGE_REPORT_KEYS;
 export const MANAGE_REPORT_OPTIONS = Object.values(MANAGE_REPORT_KEYS);
 
+// ...common steps are imported from shared/common.ts
+
 // CSV設定
 export const manageCsvConfigMap: Record<ManageReportKey, CsvConfigGroup> = {
   factory_report: [
@@ -63,58 +65,10 @@ export const manageCsvConfigMap: Record<ManageReportKey, CsvConfigGroup> = {
 
 // モーダルステップ設定
 export const manageModalStepsMap: Record<ManageReportKey, ModalStepConfig[]> = {
-  factory_report: [
-    {
-      label: "帳簿作成中",
-      content: React.createElement(
-        "div",
-        {},
-        "帳簿を作成中です。しばらくお待ちください。"
-      ),
-      showNext: false,
-      showClose: false,
-    },
-    {
-      label: "完了",
-      content: React.createElement("div", {}, "完了しました"),
-      showNext: false,
-      showClose: true,
-    },
-  ],
-  balance_sheet: [
-    {
-      label: "帳簿作成中",
-      content: React.createElement("div", {}, "帳票を生成中です"),
-      showNext: false,
-      showClose: false,
-    },
-    {
-      label: "運搬業者選択",
-      content: React.createElement(BlockUnitPriceInteractive),
-      showNext: true,
-      showClose: false,
-    },
-    {
-      label: "完了",
-      content: React.createElement("div", {}, "完了しました"),
-      showNext: false,
-      showClose: true,
-    },
-  ],
-  average_sheet: [
-    {
-      label: "帳簿作成中",
-      content: React.createElement("div", {}, "帳票を生成中です"),
-      showNext: true,
-      showClose: false,
-    },
-    {
-      label: "完了",
-      content: React.createElement("div", {}, "完了しました"),
-      showNext: false,
-      showClose: true,
-    },
-  ],
+  // factory_report と balance_sheet は同じステップなので共通定義を使う
+  factory_report: [...SIMPLE_CREATE_AND_DONE_STEPS],
+  balance_sheet: [...SIMPLE_CREATE_AND_DONE_STEPS],
+  average_sheet: [...SIMPLE_CREATE_AND_DONE_STEPS],
   block_unit_price: [
     {
       label: "帳簿作成中",

--- a/my-project/frontend/src/constants/reportConfig/shared/common.ts
+++ b/my-project/frontend/src/constants/reportConfig/shared/common.ts
@@ -1,4 +1,5 @@
 // /app/src/constants/reportConfig/shared/common.ts
+import React from 'react';
 import type { CsvConfigGroup, ModalStepConfig, ReportConfig } from './types';
 
 // ==============================
@@ -16,18 +17,17 @@ export const LEDGER_REPORT_URL = '/ledger_api/reports';
 export const REPORT_API_ENDPOINTS = {
     // 工場日報系
     factory_report: `${LEDGER_REPORT_URL}/factory_report/`,
-    // factory_report: `${LEDGER_API_URL}`,
 
     // 収支・管理表系
-    balance_sheet: '/api/report/balance',
-    average_sheet: '/api/report/average',
-    management_sheet: '/api/report/management',
+    balance_sheet: `${LEDGER_REPORT_URL}/balance_sheet/`,
+    average_sheet: `${LEDGER_REPORT_URL}/average_sheet/`,
+    management_sheet: `${LEDGER_REPORT_URL}/management_sheet/`,
 
     // インタラクティブ帳簿系
-    block_unit_price: '/ledger_api/report/block_unit_price',
+    block_unit_price: `${LEDGER_REPORT_URL}/block_unit_price`,
 
     // 台帳系（将来追加用）
-    ledger_book: '/ledger_api/report/ledger',
+    ledger_book: `${LEDGER_REPORT_URL}/ledger`,
 } as const;
 
 /**
@@ -56,6 +56,26 @@ export const INTERACTIVE_REPORTS = {
         requiresUserInput: true,
     },
 } as const;
+
+// 共通のシンプルなモーダルステップ（作成中 -> 完了）
+export const SIMPLE_CREATE_AND_DONE_STEPS: ModalStepConfig[] = [
+    {
+        label: "帳簿作成中",
+        content: React.createElement(
+            "div",
+            {},
+            "帳簿を作成中です。しばらくお待ちください。"
+        ),
+        showNext: false,
+        showClose: false,
+    },
+    {
+        label: "完了",
+        content: React.createElement("div", {}, "完了しました"),
+        showNext: false,
+        showClose: true,
+    },
+];
 
 /**
  * 帳簿がインタラクティブタイプかチェック

--- a/my-project/frontend/src/constants/reportConfig/shared/common.ts
+++ b/my-project/frontend/src/constants/reportConfig/shared/common.ts
@@ -16,15 +16,15 @@ export const LEDGER_REPORT_URL = '/ledger_api/reports';
  */
 export const REPORT_API_ENDPOINTS = {
     // 工場日報系
-    factory_report: `${LEDGER_REPORT_URL}/factory_report/`,
+    factory_report: `${LEDGER_REPORT_URL}/factory_report`,
 
     // 収支・管理表系
-    balance_sheet: `${LEDGER_REPORT_URL}/balance_sheet/`,
-    average_sheet: `${LEDGER_REPORT_URL}/average_sheet/`,
-    management_sheet: `${LEDGER_REPORT_URL}/management_sheet/`,
+    balance_sheet: `${LEDGER_REPORT_URL}/balance_sheet`,
+    average_sheet: `${LEDGER_REPORT_URL}/average_sheet`,
+    management_sheet: `${LEDGER_REPORT_URL}/management_sheet`,
 
     // インタラクティブ帳簿系
-    block_unit_price: `${LEDGER_REPORT_URL}/block_unit_price`,
+    block_unit_price: `${LEDGER_REPORT_URL}/block_unit_price_interactive`,
 
     // 台帳系（将来追加用）
     ledger_book: `${LEDGER_REPORT_URL}/ledger`,

--- a/my-project/frontend/src/constants/reportConfig/shared/types.ts
+++ b/my-project/frontend/src/constants/reportConfig/shared/types.ts
@@ -27,6 +27,8 @@ export type ReportConfig = {
     steps: string[];
     previewImage: string;
     modalSteps: ModalStepConfig[];
+    // 一部帳簿で PDF 生成関数がまだ無いケースに対応
+    generatePdf?: () => Promise<Blob | string>;
 };
 
 // 帳票キー型（各ページ設定で拡張）

--- a/my-project/frontend/src/hooks/data/useExcelGeneration.ts
+++ b/my-project/frontend/src/hooks/data/useExcelGeneration.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { notifySuccess, notifyError, notifyInfo } from '../../utils/notify';
-import type { ReportKey } from '../../constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 type CsvFiles = { [csvLabel: string]: File | null };
 

--- a/my-project/frontend/src/hooks/data/useZipFileGeneration.ts
+++ b/my-project/frontend/src/hooks/data/useZipFileGeneration.ts
@@ -1,8 +1,8 @@
 import { useState, useCallback } from 'react';
 import * as JSZip from 'jszip';
 import { notifySuccess, notifyError, notifyInfo } from '../../utils/notify';
-import { getApiEndpoint, REPORT_KEYS } from '../../constants/reportConfig';
-import type { ReportKey } from '../../constants/reportConfig';
+import { getApiEndpoint, REPORT_KEYS } from '@/constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 type CsvFiles = { [csvLabel: string]: File | null };
 

--- a/my-project/frontend/src/hooks/report/useReportBaseBusiness.ts
+++ b/my-project/frontend/src/hooks/report/useReportBaseBusiness.ts
@@ -8,7 +8,7 @@ import type {
     UploadFileConfig,
     MakeUploadPropsFn,
 } from '../../types/reportBase';
-import type { ReportKey } from '../../constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 /**
  * ReportBaseのビジネスロジックを統合管理するフック

--- a/my-project/frontend/src/hooks/report/useReportManager.ts
+++ b/my-project/frontend/src/hooks/report/useReportManager.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { reportConfigMap, modalStepsMap } from '../../constants/reportConfig';
-import type { ReportKey } from '../../constants/reportConfig';
+import { reportConfigMap, modalStepsMap } from '@/constants/reportConfig';
+import type { ReportKey } from '@/constants/reportConfig';
 
 // CSVファイルの型定義
 type CsvFiles = { [csvLabel: string]: File | null };

--- a/my-project/frontend/src/hooks/useReportManager.ts
+++ b/my-project/frontend/src/hooks/useReportManager.ts
@@ -161,6 +161,7 @@ export const useReportManager = (
                 loading: isLoading,
                 setLoading: setIsLoading,
             },
+            // generatePdf はオプショナル
             generatePdf: selectedConfig.generatePdf,
             reportKey: selectedReport,
         }),

--- a/my-project/nginx/Dockerfile
+++ b/my-project/nginx/Dockerfile
@@ -1,0 +1,38 @@
+## Multi-stage build: build React (Vite) then serve with Nginx
+## 用途: stg/prod など本番系で "Welcome to nginx!" を回避し常に dist を同梱
+
+### 1) Build stage (Node) - use Debian variant to simplify native module (canvas) build
+FROM node:20-bullseye AS build
+WORKDIR /app
+
+# Install build deps for node-canvas (needs Python, pkg-config, cairo, pango, jpeg, gif, librsvg, etc.)
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+		apt-get install -y --no-install-recommends \
+			python3 make g++ pkg-config \
+			libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+		&& rm -rf /var/lib/apt/lists/*
+
+# 依存関係のみ先にコピー (キャッシュ有効活用)
+COPY frontend/package*.json ./
+RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; else npm install --no-audit --no-fund; fi
+
+# ソース一式をコピーしてビルド
+COPY frontend/ .
+RUN npm run build
+
+### 2) Runtime stage (Nginx)
+FROM nginx:1.27-alpine AS runtime
+
+# Nginx のカスタム設定 (conf.d 全置換)
+COPY nginx/conf.d /etc/nginx/conf.d
+
+# React ビルド成果物を配置
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# (Optional) If size is critical, consider a slimmer build stage or copying only needed node_modules for a secondary build.
+
+# 健康チェック用 (任意) - statically served file 確認
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD [ -f /usr/share/nginx/html/index.html ] || exit 1
+
+EXPOSE 80 443
+CMD ["nginx", "-g", "daemon off;"]

--- a/my-project/nginx/conf.d/app.conf
+++ b/my-project/nginx/conf.d/app.conf
@@ -1,5 +1,4 @@
-# Upstreams
-upstream frontend { server frontend:80; }
+## Upstreams (frontend は静的配信へ移行したため削除)
 upstream ai_api { server ai_api:8000; }
 upstream ledger_api { server ledger_api:8000; }
 upstream sql_api { server sql_api:8000; }
@@ -8,78 +7,49 @@ upstream rag_api { server rag_api:8000; }
 # Common server block template (HTTP)
 server {
     listen 80;
-    server_name app.local;
+    # 任意の Host (LAN IP / ローカル) を受け付けるため server_name をワイルドカード運用
+    server_name _;
 
-    # Frontend (SPA) - 物理ファイルが無ければ @spa にフォールバック
+    # 静的フロント (React dist) ルート設定
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPAフォールバック
     location / {
-        try_files $uri @spa;
+        try_files $uri $uri/ /index.html;
     }
 
-    location @spa {
-        proxy_pass http://frontend;
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-    }
-
-    # API routes - keep trailing slash to strip prefix for upstream
-    location /ai_api/ {
+    # API (共通プレフィックス /api/<service>/ )
+    location /api/ai_api/ {
         include /etc/nginx/conf.d/_proxy_headers.conf;
         include /etc/nginx/conf.d/_proxy_ws.conf;
         proxy_pass http://ai_api/;
     }
-    location /ledger_api/ {
+    location /api/ledger_api/ {
         include /etc/nginx/conf.d/_proxy_headers.conf;
         include /etc/nginx/conf.d/_proxy_ws.conf;
         proxy_pass http://ledger_api/;
     }
-    location /sql_api/ {
+    location /api/sql_api/ {
         include /etc/nginx/conf.d/_proxy_headers.conf;
         include /etc/nginx/conf.d/_proxy_ws.conf;
         proxy_pass http://sql_api/;
     }
-    location /rag_api/ {
+    location /api/rag_api/ {
         include /etc/nginx/conf.d/_proxy_headers.conf;
         include /etc/nginx/conf.d/_proxy_ws.conf;
         proxy_pass http://rag_api/;
     }
+
+    # --- 互換リダイレクト (旧: /ai_api/... → /api/ai_api/...) 必要なければ削除可 ---
+    rewrite ^/ai_api/(.*)$ /api/ai_api/$1 permanent;
+    rewrite ^/ledger_api/(.*)$ /api/ledger_api/$1 permanent;
+    rewrite ^/sql_api/(.*)$ /api/sql_api/$1 permanent;
+    rewrite ^/rag_api/(.*)$ /api/rag_api/$1 permanent;
 }
 
 # Staging host
-server {
-    listen 80;
-    server_name stg.app.local;
-
-    location / {
-        try_files $uri @spa;
-    }
-
-    location @spa {
-        proxy_pass http://frontend;
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-    }
-
-    location /ai_api/ {
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-        proxy_pass http://ai_api/;
-    }
-    location /ledger_api/ {
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-        proxy_pass http://ledger_api/;
-    }
-    location /sql_api/ {
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-        proxy_pass http://sql_api/;
-    }
-    location /rag_api/ {
-        include /etc/nginx/conf.d/_proxy_headers.conf;
-        include /etc/nginx/conf.d/_proxy_ws.conf;
-        proxy_pass http://rag_api/;
-    }
-}
+## 2つ目の server ブロックは不要になったため削除 (単一設定でホスト名問わず応答)
 
 # Optional HTTPS skeleton (certs mounting expected under /etc/nginx/certs)
 server {


### PR DESCRIPTION
This pull request introduces several improvements and new features to the sanbou_app project, focusing on enhancing the interactive reporting APIs, expanding the available report endpoints, and improving documentation for onboarding and usage. The changes include a major refactor of the interactive block unit price API, the addition of new report endpoints, and the introduction of a base class for interactive report generators.

**API Improvements and Refactoring**

* Refactored the interactive block unit price API (`block_unit_price_interactive.py`) to support both legacy JSON and modern multipart file uploads, added step-wise endpoints (`/initial`, `/select-transport`, `/finalize`, `/apply`), and integrated the new `InteractiveReportProcessingService` for improved multi-step processing. [[1]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67L12-R29) [[2]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67L48-R66) [[3]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67L78-R107) [[4]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67L107-R136) [[5]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67L132-R164) [[6]](diffhunk://#diff-9f614048d34a67e172ce562b90aa75dbf80fee66ad476a1aaa07d65a880f5b67R207-R222)
* Added a new base class `BaseInteractiveReportGenerator` to standardize multi-step interactive report generation, including session state serialization/deserialization and handler dispatch for each step.

**New Report Endpoints**

* Introduced two new report endpoints: `average_sheet` and `management_sheet`, each with their own generator and API route, allowing for generation of new report types via file upload and optional period selection. [[1]](diffhunk://#diff-88faf4a875349aca9ad9ec21cc70352e582cdd9261c16202be475c905911f972R1-R45) [[2]](diffhunk://#diff-da175015a8b1df6f57be704032014ec7647ce896bbd3ec999e2a29f2c2489dd3R1-R49)
* Updated the report API router (`reports/__init__.py`) to include the new endpoints and organize all report routes under appropriate prefixes and tags. [[1]](diffhunk://#diff-887810724831492d730bb5d27ac447b485d2104f87d3598f6213f5d55b93d19fL5-R11) [[2]](diffhunk://#diff-887810724831492d730bb5d27ac447b485d2104f87d3598f6213f5d55b93d19fR25-R38)

**General API Consistency**

* Standardized all report generation endpoints to use `@router.post("")` instead of `@router.post("/")` for consistency. [[1]](diffhunk://#diff-8f146c04828b362af52634b145238ce4c50d29d54aa140191c911b38b088009bL18-R18) [[2]](diffhunk://#diff-b7ec5b64d827e618146f34bc7830c0c2683d2317e85159523e14e0dcc75b2aecL18-R18) [[3]](diffhunk://#diff-bc56cf08cf10b47513e1cdbf62c113896ebc92e58a7b74c07fbef9aa10ab10f6L18-R18)

**Documentation and Docker Improvements**

* Overhauled the main `README.md` to provide a clear quick start guide, environment setup instructions, service descriptions, and troubleshooting tips for easier onboarding and maintenance.
* Changed the nginx service in `docker-compose.yml` to build from a local Dockerfile for improved flexibility, and clarified volume mounts for hot-reloading and TLS certificate management.