### PR TITLE
Add GitHub Actions workflow for staging frontend

### DIFF
--- a/.github/workflows/stg-frontend.yml
+++ b/.github/workflows/stg-frontend.yml
@@ -1,0 +1,38 @@
+name: Build & Push Frontend (stg)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Build target (branch/tag/commit)"
+        required: false
+        default: stg
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}   # ← ここで stg（など）任意ブランチのコードを取る
+
+      - uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: sanbou-app
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Docker auth for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build & Push Frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: my-project/frontend
+          file: my-project/frontend/Dockerfile
+          push: true
+          tags: |
+            asia-northeast1-docker.pkg.dev/sanbou-app/sanbou-repo/sanbou-frontend:stg
+            asia-northeast1-docker.pkg.dev/sanbou-app/sanbou-repo/sanbou-frontend:stg-${{ github.sha }}


### PR DESCRIPTION
This workflow builds and pushes the frontend for the staging environment, allowing manual triggers with optional branch/tag/commit input.