### PR TITLE
feat_f_stg_prod_env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,30 @@
-## version キーは最新 compose では非推奨のため未指定
-##
-## 必要な事前設定（例）
-## .env などに:
-##   REGISTRY=asia-northeast1-docker.pkg.dev/sanbou-app/sanbou-repo
-##   POSTGRES_USER=...
-##   POSTGRES_PASSWORD=...
-##   POSTGRES_DB=...
-## 環境別 .env は ./env/.env.stg, ./env/.env.prod を利用
+## version キー省略 (compose v2)
+## 環境変数は .env と env/.env.{stg,prod} を併用
 
 services:
-  # =========================
-  # PROD 系
-  # =========================
+  # ------------ PROD ------------
   prod-frontend:
-    image: "${REGISTRY:-local}/sanbou-frontend:prod"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-frontend:prod"
+    build:
+      context: ./my-project/frontend
+      dockerfile: Dockerfile
+      target: runtime
     container_name: prod-frontend
-    profiles: ["edge"]
+    profiles: ["prod"]
     env_file:
       - ./env/.env.prod
-    # フロントはイメージ内で 80 番待受け想定（Nginx等）
     expose: ["80"]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: never
 
   prod-ai_api:
-    image: "${REGISTRY:-local}/sanbou-ai-api:prod"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-ai-api:prod"
+    build:
+      context: ./my-project/backend/ai_api
+      dockerfile: Dockerfile
     container_name: prod-ai_api
-    profiles: ["edge"]
+    profiles: ["prod"]
     env_file:
       - ./env/.env.prod
     environment:
@@ -36,12 +33,11 @@ services:
     depends_on:
       prod-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_prod.json
+    secrets: [gcs_key_prod.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
+    pull_policy: never
+    healthcheck: &api_hc
       test:
         - CMD-SHELL
         - |
@@ -58,9 +54,14 @@ services:
       retries: 5
 
   prod-ledger_api:
-    image: "${REGISTRY:-local}/sanbou-ledger-api:prod"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-ledger-api:prod"
+    build:
+      context: ./my-project/backend
+      dockerfile: ledger_api/Dockerfile
+      args:
+        SERVICE_DIR: ledger_api
     container_name: prod-ledger_api
-    profiles: ["edge"]
+    profiles: ["prod"]
     env_file:
       - ./env/.env.prod
     environment:
@@ -69,31 +70,21 @@ services:
     depends_on:
       prod-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_prod.json
+    secrets: [gcs_key_prod.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   prod-sql_api:
-    image: "${REGISTRY:-local}/sanbou-sql-api:prod"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-sql-api:prod"
+    build:
+      context: ./my-project/backend
+      dockerfile: sql_api/Dockerfile
+      args:
+        SERVICE_DIR: sql_api
     container_name: prod-sql_api
-    profiles: ["edge"]
+    profiles: ["prod"]
     env_file:
       - ./env/.env.prod
     environment:
@@ -102,66 +93,41 @@ services:
     depends_on:
       prod-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_prod.json
+    secrets: [gcs_key_prod.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   prod-rag_api:
-    image: "${REGISTRY:-local}/sanbou-rag-api:prod"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-rag-api:prod"
+    build:
+      context: ./my-project/backend
+      dockerfile: rag_api/Dockerfile
+      args:
+        SERVICE_DIR: rag_api
     container_name: prod-rag_api
-    profiles: ["edge"]
+    profiles: ["prod"]
     env_file:
       - ./env/.env.prod
     environment:
       DATABASE_URL: "postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@prod-db:5432/${POSTGRES_DB}"
       PYTHONPATH: ${PYTHONPATH:-/backend}
+      SKIP_GCS: ${SKIP_GCS:-1}  # ローカル検証時はデフォルトで GCS ダウンロードをスキップ
     depends_on:
       prod-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_prod.json
+    secrets: [gcs_key_prod.json, gcs_key.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   prod-db:
     image: postgres:16
     container_name: prod-db
-    profiles: ["edge"]
-    env_file:
-      - ./env/.env.prod
+    profiles: ["prod"]
+    env_file: [./env/.env.prod]
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -177,24 +143,29 @@ services:
       timeout: 5s
       retries: 6
 
-  # =========================
-  # STG 系
-  # =========================
+  # ------------ STG ------------
   stg-frontend:
-    image: "${REGISTRY:-local}/sanbou-frontend:stg"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-frontend:stg"
+    build:
+      context: ./my-project/frontend
+      dockerfile: Dockerfile
+      target: runtime
     container_name: stg-frontend
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     expose: ["80"]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: never
 
   stg-ai_api:
-    image: "${REGISTRY:-local}/sanbou-ai-api:stg"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-ai-api:stg"
+    build:
+      context: ./my-project/backend/ai_api
+      dockerfile: Dockerfile
     container_name: stg-ai_api
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     environment:
@@ -203,31 +174,21 @@ services:
     depends_on:
       stg-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_stg.json
+    secrets: [gcs_key_stg.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   stg-ledger_api:
-    image: "${REGISTRY:-local}/sanbou-ledger-api:stg"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-ledger-api:stg"
+    build:
+      context: ./my-project/backend
+      dockerfile: ledger_api/Dockerfile
+      args:
+        SERVICE_DIR: ledger_api
     container_name: stg-ledger_api
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     environment:
@@ -236,31 +197,21 @@ services:
     depends_on:
       stg-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_stg.json
+    secrets: [gcs_key_stg.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   stg-sql_api:
-    image: "${REGISTRY:-local}/sanbou-sql-api:stg"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-sql-api:stg"
+    build:
+      context: ./my-project/backend
+      dockerfile: sql_api/Dockerfile
+      args:
+        SERVICE_DIR: sql_api
     container_name: stg-sql_api
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     environment:
@@ -269,64 +220,40 @@ services:
     depends_on:
       stg-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_stg.json
+    secrets: [gcs_key_stg.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   stg-rag_api:
-    image: "${REGISTRY:-local}/sanbou-rag-api:stg"
+    image: "${LOCAL_REGISTRY:-local}/sanbou-rag-api:stg"
+    build:
+      context: ./my-project/backend
+      dockerfile: rag_api/Dockerfile
+      args:
+        SERVICE_DIR: rag_api
     container_name: stg-rag_api
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     environment:
       DATABASE_URL: "postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@stg-db:5432/${POSTGRES_DB}"
       PYTHONPATH: ${PYTHONPATH:-/backend}
+      SKIP_GCS: ${SKIP_GCS:-1}
     depends_on:
       stg-db:
         condition: service_healthy
-    secrets:
-      - gcs_key_stg.json
+    secrets: [gcs_key_stg.json, gcs_key.json]
     networks: [backend]
     restart: unless-stopped
-    pull_policy: always
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - |
-          python3 - <<'PY'
-          import sys,urllib.request
-          try:
-            r=urllib.request.urlopen('http://localhost:8000/health', timeout=3)
-            sys.exit(0 if r.getcode()==200 else 1)
-          except Exception:
-            sys.exit(1)
-          PY
-      interval: 20s
-      timeout: 5s
-      retries: 5
+    pull_policy: never
+    healthcheck: *api_hc
 
   stg-db:
     image: postgres:16
     container_name: stg-db
-    profiles: ["edge"]
+    profiles: ["stg"]
     env_file:
       - ./env/.env.stg
     environment:
@@ -344,28 +271,38 @@ services:
       timeout: 5s
       retries: 6
 
-  # =========================
-  # NGINX (リバースプロキシ)
-  # =========================
-  nginx:
+  # ------------ NGINX (分離) ------------
+  prod-nginx:
     image: nginx:1.27
-    container_name: edge-nginx
-    profiles: ["edge"]
-    ports: ["80:80", "443:443"]
+    container_name: prod-nginx
+    profiles: ["prod"]
+    ports: ["8080:80"]
     networks: [backend]
     restart: unless-stopped
     depends_on:
-      prod-ai_api:   { condition: service_healthy }
-      prod-ledger_api:{ condition: service_healthy }
-      prod-sql_api:  { condition: service_healthy }
-      prod-rag_api:  { condition: service_healthy }
-      stg-ai_api:    { condition: service_healthy }
-      stg-ledger_api:{ condition: service_healthy }
-      stg-sql_api:   { condition: service_healthy }
-      stg-rag_api:   { condition: service_healthy }
+      prod-ai_api: {condition: service_healthy}
+      prod-ledger_api: {condition: service_healthy}
+      prod-sql_api: {condition: service_healthy}
+      prod-rag_api: {condition: service_healthy}
     volumes:
-      - ./my-project/nginx/conf.d:/etc/nginx/conf.d:ro   # / と /stg/ の振分け設定を配置
-      - ./my-project/nginx/certs:/etc/nginx/certs:ro     # 任意: TLS
+      - ./my-project/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./my-project/nginx/certs:/etc/nginx/certs:ro
+
+  stg-nginx:
+    image: nginx:1.27
+    container_name: stg-nginx
+    profiles: ["stg"]
+    ports: ["8081:80"]
+    networks: [backend]
+    restart: unless-stopped
+    depends_on:
+      stg-ai_api: {condition: service_healthy}
+      stg-ledger_api: {condition: service_healthy}
+      stg-sql_api: {condition: service_healthy}
+      stg-rag_api: {condition: service_healthy}
+    volumes:
+      - ./my-project/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./my-project/nginx/certs:/etc/nginx/certs:ro
 
 networks:
   backend:
@@ -376,6 +313,8 @@ volumes:
   dbdata_stg:
 
 secrets:
+  gcs_key.json:
+    file: ./secrets/gcs-key.stg.json
   gcs_key_prod.json:
     file: ./secrets/gcs-key.prod.json
   gcs_key_stg.json:

--- a/my-project/backend/backend_shared/config/__init__.py
+++ b/my-project/backend/backend_shared/config/__init__.py
@@ -1,0 +1,1 @@
+# Makes config a package

--- a/my-project/backend/ledger_api/Dockerfile
+++ b/my-project/backend/ledger_api/Dockerfile
@@ -9,8 +9,11 @@
 FROM python:3.11-slim AS builder
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /build
+ARG SERVICE_DIR=ledger_api
 
-COPY requirements.txt requirements-dev.txt ./
+# サービス個別の requirements をルート build context からコピー
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
+COPY ${SERVICE_DIR}/requirements-dev.txt requirements-dev.txt
 ARG INSTALL_DEV=false
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip wheel --no-deps -r requirements.txt -w /wheels \
@@ -22,6 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/backend
 WORKDIR /backend
+ARG SERVICE_DIR=ledger_api
 
 # LibreOffice と日本語フォント、ヘルスチェック用 curl
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -39,17 +43,20 @@ RUN useradd -m appuser
 
 # Python 依存関係
 COPY --from=builder /wheels /wheels
-COPY requirements.txt requirements-dev.txt ./
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
+COPY ${SERVICE_DIR}/requirements-dev.txt requirements-dev.txt
 ARG INSTALL_DEV=false
 RUN pip install --no-cache-dir /wheels/*.whl \
     && if [ "$INSTALL_DEV" = "true" ]; then \
          pip install --no-cache-dir -r requirements-dev.txt; \
        fi
 
-# アプリ本体
+# アプリ本体と共有コード
 COPY backend_shared/ /backend/backend_shared
-COPY app /backend/app
-# COPY config /backend/config
+COPY ${SERVICE_DIR}/app /backend/app
+# ログ出力用ディレクトリを作成し書き込み権限を付与
+RUN mkdir -p /backend/app/api/st_app/logs \
+  && chown -R appuser:appuser /backend
 
 USER appuser
 EXPOSE 8000

--- a/my-project/backend/rag_api/Dockerfile
+++ b/my-project/backend/rag_api/Dockerfile
@@ -7,18 +7,20 @@
 FROM python:3.11-slim AS builder
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /build
+ARG SERVICE_DIR=rag_api
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg lsb-release ca-certificates \
     && curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
     && apt-get update && apt-get install -y --no-install-recommends google-cloud-sdk build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt ./requirements.txt
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip wheel --no-deps -r requirements.txt -w /wheels
 
 FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/backend PATH="/home/appuser/.local/bin:${PATH}"
 WORKDIR /backend
+ARG SERVICE_DIR=rag_api
 RUN useradd -m appuser
 USER appuser
 
@@ -30,7 +32,7 @@ RUN mkdir -p /home/appuser/.config/gcloud && chown -R appuser:appuser /home/appu
 
 # deps
 COPY --from=builder /wheels /wheels
-COPY requirements.txt ./requirements.txt
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -39,11 +41,16 @@ RUN pip install --no-cache-dir /wheels/*.whl
 
 USER appuser
 COPY backend_shared/ /backend/backend_shared
-COPY app /backend/app
-# COPY config /backend/config
-COPY startup.sh /backend/startup.sh
+COPY ${SERVICE_DIR}/app /backend/app
+COPY ${SERVICE_DIR}/startup.sh /backend/startup.sh
 USER root
 RUN chmod +x /backend/startup.sh && chown appuser:appuser /backend/startup.sh
+USER appuser
+
+# static 配信ディレクトリを先に作成 & 所有権付与（実行時 PermissionError 対策）
+USER root
+RUN mkdir -p /backend/static/pdfs /backend/static/test_pdfs \
+    && chown -R appuser:appuser /backend/static
 USER appuser
 
 EXPOSE 8000

--- a/my-project/backend/rag_api/startup.sh
+++ b/my-project/backend/rag_api/startup.sh
@@ -6,7 +6,20 @@ IFS=$'\n\t'
 # --- 設定値（環境変数で上書き可能） ---
 GCS_BUCKET_NAME="${GCS_BUCKET_NAME:-object_haikibutu}"
 GCS_DATA_PREFIX="${GCS_DATA_PREFIX:-master}"
-TARGET_DIR="${TARGET_DIR:-${APP_BASE_DIR:-/app}/local_data/master}"
+# /backend が書き込み不可な場合はホームへフォールバック
+TARGET_DIR_DEFAULT="${APP_BASE_DIR:-/backend}/local_data/master"
+TARGET_DIR="${TARGET_DIR:-$TARGET_DIR_DEFAULT}"
+# root 権限で作成し所有権付与 (コンテナは appuser 実行)
+if mkdir -p "${TARGET_DIR%/master}" 2>/dev/null; then
+  :
+else
+  # /backend に書けない場合はホームへフォールバック
+  TARGET_DIR="/home/appuser/local_data/master"
+  mkdir -p "${TARGET_DIR%/master}" || true
+fi
+if command -v chown >/dev/null 2>&1; then
+  chown -R appuser:appuser "${TARGET_DIR%/master}" 2>/dev/null || true
+fi
 GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-/root/.config/gcloud/application_default_credentials.json}"
 
 # --- 関数化：GCSからデータ取得 ---
@@ -25,19 +38,38 @@ download_gcs_data() {
   fi
 }
 
-# --- GCP認証 ---
-if ! gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"; then
-  echo "❌ GCPサービスアカウント認証に失敗しました" >&2
-  exit 10
+# --- GCP認証 (スキップ条件付き) ---
+SKIP_GCS="${SKIP_GCS:-0}"
+if [[ "$SKIP_GCS" == "1" ]]; then
+  echo "⚠️  SKIP_GCS=1 が指定されたため GCS 処理をスキップします。"
+else
+  if ! command -v gcloud >/dev/null 2>&1 || ! command -v gsutil >/dev/null 2>&1; then
+    echo "⚠️  gcloud/gsutil が見つからないため GCS 処理をスキップします。" >&2
+    SKIP_GCS=1
+  elif [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+    echo "⚠️  認証ファイル $GOOGLE_APPLICATION_CREDENTIALS が無いため GCS 処理をスキップします。" >&2
+    SKIP_GCS=1
+  fi
+  if [[ "$SKIP_GCS" != "1" ]]; then
+    if gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"; then
+      echo "✅ Authenticated with service account."
+    else
+      echo "⚠️  サービスアカウント認証に失敗。GCS 処理をスキップします。" >&2
+      SKIP_GCS=1
+    fi
+  fi
 fi
-echo "✅ Authenticated with service account."
 
 # --- データ取得（拡張ポイント：他データ種別もここで追加可能） ---
-if [ -n "$(ls -A "$TARGET_DIR" 2>/dev/null || true)" ]; then
-  echo "⏩ [1/2] Local data already exists. Skipping GCS download."
+if [[ "$SKIP_GCS" == "1" ]]; then
+  echo "⏩ [GCS] スキップ指定のためダウンロード無しで続行します。"
 else
-  if ! download_gcs_data "$GCS_BUCKET_NAME" "$GCS_DATA_PREFIX" "$TARGET_DIR"; then
-    exit 20
+  if [ -n "$(ls -A "$TARGET_DIR" 2>/dev/null || true)" ]; then
+    echo "⏩ [1/2] Local data already exists. Skipping GCS download."
+  else
+    if ! download_gcs_data "$GCS_BUCKET_NAME" "$GCS_DATA_PREFIX" "$TARGET_DIR"; then
+      echo "⚠️  ダウンロード失敗しましたが起動は継続します。" >&2
+    fi
   fi
 fi
 

--- a/my-project/backend/sql_api/Dockerfile
+++ b/my-project/backend/sql_api/Dockerfile
@@ -5,8 +5,10 @@
 
 FROM python:3.11-slim AS builder
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
-WORKDIR /wheels
-COPY requirements.txt requirements-dev.txt ./
+WORKDIR /build
+ARG SERVICE_DIR=sql_api
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
+COPY ${SERVICE_DIR}/requirements-dev.txt requirements-dev.txt
 ARG INSTALL_DEV=false
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
@@ -17,11 +19,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/backend PATH="/home/appuser/.local/bin:${PATH}"
 WORKDIR /backend
+ARG SERVICE_DIR=sql_api
 RUN useradd -m appuser
 USER appuser
 
 COPY --from=builder /wheels /wheels
-COPY requirements.txt requirements-dev.txt ./
+COPY ${SERVICE_DIR}/requirements.txt requirements.txt
+COPY ${SERVICE_DIR}/requirements-dev.txt requirements-dev.txt
 ARG INSTALL_DEV=false
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
@@ -31,7 +35,7 @@ RUN pip install --no-cache-dir /wheels/*.whl \
     && if [ "$INSTALL_DEV" = "true" ]; then pip install --no-cache-dir -r requirements-dev.txt; fi
 
 COPY backend_shared/ /backend/backend_shared
-COPY app /backend/app
+COPY ${SERVICE_DIR}/app /backend/app
 # COPY config /backend/config
 
 EXPOSE 8000


### PR DESCRIPTION
This pull request refactors the Docker Compose and Makefile setup to improve local development and environment management for both staging (`stg`) and production (`prod`). The changes introduce local image building for all services, streamline secret handling, and split the Nginx reverse proxy configuration per environment. The Makefile is updated to support these changes, including improved secret file management and an option to skip remote image pulls.

**Docker Compose and Environment Management Improvements:**

* All service images now use the `LOCAL_REGISTRY` variable and include build instructions for local builds, enabling easier local development and testing without relying on remote image pulls. (`docker-compose.yml`, [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R27) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L61-R64) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L105-R130) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L180-R168) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L239-R214) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L272-R256)
* Nginx reverse proxy is split into `prod-nginx` and `stg-nginx` services, each with its own profile and port, improving separation and clarity between environments. (`docker-compose.yml`, [docker-compose.ymlL347-R305](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L347-R305))
* Secret handling is streamlined: secrets are now referenced as arrays, and generic/stage/production GCS key files are managed more consistently. (`docker-compose.yml`, [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R40) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L72-R87) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L206-R191) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R316-R317)

**Makefile Enhancements:**

* The Makefile now includes logic to automatically copy or duplicate GCS key files for the appropriate environment, reducing manual setup steps. (`makefile`, [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R109-R123) [[2]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R219-R232)
* A new `REMOTE_PULL` variable allows developers to control whether images are pulled from a remote registry or built locally, improving workflow flexibility. (`makefile`, [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R23-R40) [[2]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R155-R163) [[3]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R242-R254)
* Compose profiles are explicitly set for `stg` and `prod` environments, replacing the legacy `edge` profile. (`makefile`, [makefileR56-R61](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R56-R61))

**Miscellaneous:**

* Adds an empty `__init__.py` to `backend_shared/config` to ensure it is recognized as a Python package. (`my-project/backend/backend_shared/config/__init__.py`, [my-project/backend/backend_shared/config/__init__.pyR1](diffhunk://#diff-889d938fe0d2486b387ed785f6e4fa99c5dec0cdac6482fab8348b6471704dbfR1))
* Updates the `ledger_api/Dockerfile` to use a `SERVICE_DIR` build argument for copying service-specific requirements, aligning with the new build context structure. (`my-project/backend/ledger_api/Dockerfile`, [my-project/backend/ledger_api/DockerfileR12-R16](diffhunk://#diff-2ccc419297fdbcc3f172c7a6221dafe62f3647ee7294895c9902d68d57d6ba9fR12-R16))